### PR TITLE
EE-21428 Run e2e tests after push to master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -85,7 +85,7 @@ pipeline:
       event: tag
 
   trigger-e2e-tests:
-    image: quay.io/ukhomeofficedigital/drone-trigger:latest
+    image: quay.io/ukhomeofficedigital/drone-trigger:v0.3.0
     secrets:
       - DRONE_TOKEN
     drone_server: https://drone.acp.homeoffice.gov.uk

--- a/.drone.yml
+++ b/.drone.yml
@@ -84,6 +84,17 @@ pipeline:
     when:
       event: tag
 
+  trigger-e2e-tests:
+    image: quay.io/ukhomeofficedigital/drone-trigger:latest
+    secrets:
+      - DRONE_TOKEN
+    drone_server: https://drone.acp.homeoffice.gov.uk
+    repo: UKHomeOffice/pttg-ip-e2e-tests
+    branch: master
+    when:
+      branch: [master]
+      event: push
+
   clone-kube-project:
     image: plugins/git
     commands:


### PR DESCRIPTION
Trigger the e2e tests after a merge onto master branch. This still leaves us somewhat short of a good solution for integrating e2e tests into the build pipeline (EE-21386) but at least the e2e tests are being run.